### PR TITLE
[Editorial] Fix links to Opt-In in container-metrics.md

### DIFF
--- a/docs/system/container-metrics.md
+++ b/docs/system/container-metrics.md
@@ -200,4 +200,4 @@ This metric is [opt-in][MetricOptIn].
 <!-- endsemconv -->
 
 [DocumentStatus]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/document-status.md
-[MetricOptIn]: https://github.com/open-telemetry/opentelemetry-specification/tree/v1.33.0/specification/metrics/metric-requirement-level.md#opt-in
+[MetricOptIn]: https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/general/metric-requirement-level.md#opt-in


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/pull/4519:

```
docs/specs/semconv/system/container-metrics/index.html
  hash does not exist --- docs/specs/semconv/system/container-metrics/index.html --> /docs/specs/otel/metrics/metric-requirement-level/#opt-in
  hash does not exist --- docs/specs/semconv/system/container-metrics/index.html --> /docs/specs/otel/metrics/metric-requirement-level/#opt-in
  hash does not exist --- docs/specs/semconv/system/container-metrics/index.html --> /docs/specs/otel/metrics/metric-requirement-level/#opt-in
  hash does not exist --- docs/specs/semconv/system/container-metrics/index.html --> /docs/specs/otel/metrics/metric-requirement-level/#opt-in
```

@chalin is out of office, so I try my best to get this fixed:-) I am not sure how we address this since this fix will not be included in the release that https://github.com/open-telemetry/opentelemetry.io/pull/4519 is referencing